### PR TITLE
temphum24: add function to read the serial number

### DIFF
--- a/clicks/temphum24/lib_temphum24/include/temphum24.h
+++ b/clicks/temphum24/lib_temphum24/include/temphum24.h
@@ -474,6 +474,19 @@ err_t temphum24_start_measurement ( temphum24_t *ctx );
  */
 err_t temphum24_stop_measurement ( temphum24_t *ctx );
 
+/**
+ * @brief TempHum 24 read serial number function.
+ * @details This function reads the serial number/NIST ID.
+ * @param[in] ctx : Click context object.
+ * See #temphum24_t object definition for detailed explanation.
+ * @param[out] serial_number : Pointer to the memory location where serial number value be stored.
+ * @return @li @c  0 - Success,
+ *         @li @c -1 - Error.
+ * See #err_t definition for detailed explanation.
+ * @note None.
+ */
+err_t temphum24_get_serial_number ( temphum24_t *ctx, uint16_t *serial_number );
+
 #ifdef __cplusplus
 }
 #endif

--- a/clicks/temphum24/lib_temphum24/src/temphum24.c
+++ b/clicks/temphum24/lib_temphum24/src/temphum24.c
@@ -284,6 +284,23 @@ err_t temphum24_stop_measurement ( temphum24_t *ctx )
     return temphum24_write_cmd ( ctx, TEMPHUM24_CMD_AUTO_MEAS_EXIT );
 }
 
+err_t temphum24_get_serial_number ( temphum24_t *ctx, uint16_t *serial_number )
+{
+    err_t error_flag;
+
+    for ( uint8_t i = 0; i < 3; i++ )
+    {
+        error_flag = temphum24_write_then_read_single( ctx, TEMPHUM24_CMD_READ_NIST_ID_BYTES_5_4+i,
+                                                       &serial_number[ i ] );
+        if ( error_flag < 0 )
+        {
+            return error_flag;
+        }
+    }
+
+    return TEMPHUM24_OK;
+}
+
 static uint8_t temphum24_calculate_crc ( uint8_t *crc_source )
 {
     uint8_t crc = TEMPHUM24_INIT_VALUE;


### PR DESCRIPTION
This PR adds a function to read the serial number / NIST ID of the HDC302x.

It has the same signature and usage as the one from the `hvac` click:

https://github.com/MikroElektronika/mikrosdk_click_v2/blob/763a401a4415595cd7e3b72df0fec8fb66bd39fc/clicks/hvac/lib_hvac/src/hvac.c#L234
